### PR TITLE
Fix freetype include path

### DIFF
--- a/MontageLib/Viewer/mViewer_graphics.c
+++ b/MontageLib/Viewer/mViewer_graphics.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <freetype2/ft2build.h>
-#include <freetype.h>
+#include FT_FREETYPE_H
 
 void  mViewer_labeledCurve (char *face_path, int fontsize, int showLine,
                             double *xcurve, double *ycurve, int npt,  

--- a/util/Viewer/graphics.c
+++ b/util/Viewer/graphics.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <math.h>
 #include <freetype2/ft2build.h>
-#include <freetype.h>
+#include FT_FREETYPE_H
 
 void labeled_curve (char *face_path, int fontsize, int showLine,
                     double *xcurve, double *ycurve, int npt,  


### PR DESCRIPTION
According to the [FreeType Tutorial](https://www.freetype.org/freetype2/docs/tutorial/step1.html), the `#include` of the freetype header file shall not be done directly as `freetype.h`, but via the macro `FT_FREETYPE_H`. This is required to get the package build with a range of external freetype libraries.