### PR TITLE
non-void function 'closefitsfile' should return a value

### DIFF
--- a/lib/src/two_plane_v1.1/initdistdata.c
+++ b/lib/src/two_plane_v1.1/initdistdata.c
@@ -33,9 +33,9 @@ void closefitsfile()
   if (I_fits_return_status != 0)
   {
      fprintf(stderr, "Error closing file\n");
-     return;
+     return -1;
   }
-  return;    
+  return 0;
 }
 
 int initdata_byheader(char *fitsheader, DistCoeff *coeff) 


### PR DESCRIPTION
This is a patch of @cdeil copied from [macports](https://trac.macports.org/attachment/ticket/41076/patch-lib-src-two_plane_v1.1-initdistdata.c.diff). It irequired if one tries to compile f.e. with gcc-6.
This fixes the build on Debian, and on MacPorts. For details see the [Macports ticket 41766](https://trac.macports.org/ticket/41076).

