### PR TITLE
Remove unneeded prototype declaration for strdup().

### DIFF
--- a/grid/Pegasus/hashtable.c
+++ b/grid/Pegasus/hashtable.c
@@ -4,8 +4,6 @@
 
 #include <hashtable.h>
 
-char *strdup(const char *s1);
-
 int HT_debug = 0;
 
 /********************************************************/

--- a/lib/src/coord/ccalc.c
+++ b/lib/src/coord/ccalc.c
@@ -25,7 +25,6 @@ static int ConverttoDD(char *fmt, char *clon, char *clat, double *lon,
 static int ConvertfromDD(char *fmt, char *clongprec, char *clatprec, 
 			 char *clon, char *clat, double *lon, double *lat);
 static char *downcase(char *s);
-char *strdup(const char *s1);
 int ParseUnits(char *cunit, int *chflag, CoordUnit *unit);
 int ParsePrec(CoordUnit units, char *cprec, int longflag);
 


### PR DESCRIPTION
`strdup()` is already defined in `string.h` which is included in `ccalc.c`.  Since strdup may be a macro, the additional declaration lead to the following error message under Debian:

```
make[4]: Entering directory '/build/montage-5.0+dfsg/lib/src/coord'
gcc -g -O2 -fdebug-prefix-map=/build/montage-5.0+dfsg=. -fstack-protector-strong
In file included from /usr/include/string.h:630:0,
                 from ccalc.c:5:
ccalc.c:28:7: error: expected identifier or '(' before '__extension__'
 char *strdup(const char *s1);
       ^
<builtin>: recipe for target 'ccalc.o' failed
make[4]: *** [ccalc.o] Error 1
```