### PR TITLE
non-void function 'closefitsfile' should return a value

### DIFF
--- a/lib/src/two_plane_v1.1/initdistdata.c
+++ b/lib/src/two_plane_v1.1/initdistdata.c
@@ -33,9 +33,9 @@ void closefitsfile()
   if (I_fits_return_status != 0)
   {
      fprintf(stderr, "Error closing file\n");
-     return;
+     return -1;
   }
-  return;    
+  return 0;
 }
 
 int initdata_byheader(char *fitsheader, DistCoeff *coeff) 


### PR DESCRIPTION
This is an older patch copied from [macports](https://trac.macports.org/browser/trunk/dports/science/montage/files/patch-lib-src-two_plane_v1.1-initdistdata.c.diff).
Credits go to @astrofrog (or @cdeil, who was set as author of this patch in Debian?).


