### PR TITLE
Initialize maxcntr in montageBgExec

### DIFF
--- a/MontageLib/BgExec/montageBgExec.c
+++ b/MontageLib/BgExec/montageBgExec.c
@@ -80,7 +80,7 @@ struct mBgExecReturn *mBgExec(char *inpath, char *tblfile, char *fitfile, char *
    int    ib;
    int    ic;
 
-   int    cntr, maxcntr;
+   int    cntr, maxcntr = 0;
    double *a;
    double *b;
    double *c;


### PR DESCRIPTION
Otherwise, `maxcntr` is initialized by some random value, which is later used to allocate memory. When this exceeds the available memory, the Linux OOM killer may kill the program.
This regularly happens when montage is called by the test procedures in montage-wrapper in Debian, f.e. [here](https://ci.debian.net/data/autopkgtest/unstable/amd64/m/montage-wrapper/1494489/log.gz) (The invalid/empty  astroscrappy  file comes from bgExec that crashed before mAdd was run).