### PR TITLE
Fix memory leaks in mAdd

### DIFF
--- a/Montage/mAdd.c
+++ b/Montage/mAdd.c
@@ -2,6 +2,7 @@
 
 Version  Developer        Date     Change
 -------  ---------------  -------  -----------------------
+5.4      Michel Kraemer   05Aug19  Fix memory leak
 5.3      John Good        08Sep15  fits_read_pix() incorrect null value
 5.2      Daniel S. Katz   16Jul10  Small change for MPI with new fits library
 5.1      John Good        09Jul06  Only show maxopen warning in debug mode
@@ -1668,6 +1669,9 @@ int main(int argc, char **argv)
                sprintf(errstr, "Image %s header EQUINOX does not match template", infile[ifile]);
                printError(errstr);
             }
+
+            wcsfree(imgWCS);
+            free(inputHeader);
          } 
 
 

--- a/MontageLib/Add/montageAdd.c
+++ b/MontageLib/Add/montageAdd.c
@@ -2,7 +2,8 @@
 
 Version  Developer        Date     Change
 -------  ---------------  -------  -----------------------
-5.2      John Good        26Apr17  Added SUM 'averaging' mode (for X-ray observers)
+5.5      Michel Kraemer   05Aug19  Fix memory leak
+5.4      John Good        26Apr17  Added SUM 'averaging' mode (for X-ray observers)
 5.3      John Good        08Sep15  fits_read_pix() incorrect null value
 5.2      Daniel S. Katz   16Jul10  Small change for MPI with new fits library
 5.1      John Good        09Jul06  Only show maxopen warning in debug mode
@@ -1641,6 +1642,9 @@ struct mAddReturn *mAdd(char *inpath, char *tblfile, char *template_file, char *
                strcpy(returnStruct->msg, montage_msgstr);
                return returnStruct;
             }
+
+            wcsfree(imgWCS);
+            free(inputHeader);
          } 
 
 


### PR DESCRIPTION
Using valgrind, I found and fixed a memory leak in mAdd that occurs when you try to merge a large number of files.