### PR TITLE
Add dependency for Montagelib Make targets

### DIFF
--- a/MontageLib/Makefile
+++ b/MontageLib/Makefile
@@ -56,7 +56,7 @@ pgm:
 		(cd FitExec       && $(MAKE) && $(MAKE) install)
 		(cd ProjExec      && $(MAKE) && $(MAKE) install)
 
-lib:
+lib: pgm
 		rm -f libmontage.a libmontage.so libmontagepy.so
 		ar q  libmontage.a \
 			util/checkFile.o util/checkHdr.o util/checkWCS.o \
@@ -159,7 +159,7 @@ lib:
 			DiffFitExec/montageDiffFitExec.o \
 			ProjExec/montageProjExec.o 
 
-pythonlibs:
+pythonlibs: pgm
 		rm -f ../python/MontagePy/lib/*.o
 		mkdir -p ../python/MontagePy/lib
 		cp util/checkFile.o util/checkHdr.o util/checkWCS.o \


### PR DESCRIPTION
The **lib** and **pythonlibs** targets need the files that were created with **pgm**, so this dependency is required. Otherwise a parallel build fails.

BTW, if the sequential **make** calls in **pgm** are independent, they could be converted to individual targets, which would make a parallel build more efficient.