### PR TITLE
Include string.h in mPresentation.c to declare strcpy()

### DIFF
--- a/grid/Pegasus/mPresentation.c
+++ b/grid/Pegasus/mPresentation.c
@@ -14,6 +14,7 @@ Version  Developer        Date     Change
 #include <stdlib.h>
 #include <unistd.h>
 #include <strings.h>
+#include <string.h>
 
 #define MAXLEN 20000
 


### PR DESCRIPTION
Otherwise, one gets the error (with gcc-14)
```
gcc -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -g -O2 -I. -I../../Montage -I../../lib/include  -c  mPresentation.c
mPresentation.c: In function ‘main’:
mPresentation.c:54:4: error: implicit declaration of function ‘strcpy’ [-Wimplicit-function-declaration]
   54 |    strcpy(urlbase,  argv[1]);
      |    ^~~~~~
mPresentation.c:17:1: note: include ‘<string.h>’ or provide a declaration of ‘strcpy’
   16 | #include <strings.h>
  +++ |+#include <string.h>
   17 | 
mPresentation.c:54:4: warning: incompatible implicit declaration of built-in function ‘strcpy’ [-Wbuiltin-declaration-mismatch]
   54 |    strcpy(urlbase,  argv[1]);
      |    ^~~~~~
mPresentation.c:54:4: note: include ‘<string.h>’ or provide a declaration of ‘strcpy’
make[2]: *** [Makefile:23: mPresentation.o] Fehler 1
```
Closes: #79 